### PR TITLE
Added simple modes, Fixed dp hostile target

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1037,15 +1037,29 @@ public enum CustomComboPreset
 
     #region Simple Mode
 
-    //TODO
+    [AutoAction(false, false)]
+    [ReplaceSkill(DNC.Cascade)]
+    [ConflictingCombos(DNC_ST_MultiButton, DNC_ST_AdvancedMode)]
+    [CustomComboInfo("SimpleMode - Single Target",
+        "Replaces Cascade with a full one-button single target rotation. Employs the triple weave antidrift solution.", DNC.JobID)]
+    DNC_ST_SimpleMode = 4001,
+
+    [AutoAction(true, false)]
+    [ReplaceSkill(DNC.Windmill)]
+    [ConflictingCombos(DNC_AoE_MultiButton, DNC_AoE_AdvancedMode)]
+    [CustomComboInfo("SimpleMode - AoE",
+        "Replaces Windmill with a full one-button AoE rotation.",
+        DNC.JobID)]
+    DNC_AoE_SimpleMode = 4002,
 
     #endregion
+    // Last value = 4002
 
     #region Advanced Dancer (Single Target)
 
     [AutoAction(false, false)]
     [ReplaceSkill(DNC.Cascade)]
-    [ConflictingCombos(DNC_ST_MultiButton)]
+    [ConflictingCombos(DNC_ST_MultiButton, DNC_ST_SimpleMode)]
     [CustomComboInfo("Advanced Mode - Single Target",
         "Replaces Cascade with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.", DNC.JobID)]
     DNC_ST_AdvancedMode = 4010,
@@ -1151,7 +1165,7 @@ public enum CustomComboPreset
 
     [AutoAction(true, false)]
     [ReplaceSkill(DNC.Windmill)]
-    [ConflictingCombos(DNC_AoE_MultiButton)]
+    [ConflictingCombos(DNC_AoE_MultiButton, DNC_AoE_SimpleMode)]
     [CustomComboInfo("Advanced Mode - AoE",
         "Replaces Windmill with a full one-button AoE rotation.\nThese features are ideal if you want to customize the rotation.",
         DNC.JobID)]
@@ -1238,7 +1252,7 @@ public enum CustomComboPreset
 
     [AutoAction(false, false)]
     [ReplaceSkill(DNC.Cascade)]
-    [ConflictingCombos(DNC_ST_AdvancedMode)]
+    [ConflictingCombos(DNC_ST_AdvancedMode, DNC_ST_SimpleMode)]
     [CustomComboInfo("Single Target Multibutton Feature", "Single target combo with Fan Dances and Esprit use.",
         DNC.JobID)]
     DNC_ST_MultiButton = 4070,
@@ -1263,7 +1277,7 @@ public enum CustomComboPreset
 
     [AutoAction(true, false)]
     [ReplaceSkill(DNC.Windmill)]
-    [ConflictingCombos(DNC_AoE_AdvancedMode)]
+    [ConflictingCombos(DNC_AoE_AdvancedMode, DNC_AoE_SimpleMode)]
     [CustomComboInfo("AoE Multibutton Feature", "AoE combo with Fan Dances and Esprit use.", DNC.JobID)]
     DNC_AoE_MultiButton = 4090,
 


### PR DESCRIPTION
dp, removed hostile tags for it specifically, and moved above opener in st advanced. 

Single Target simple

Dance Partner remains with its auto rotation logic applied. If anyone needs that feature its the dancers that run simple. 
Removed Opener
Removed Peleton prepull
Left Standard step prepull
Removed Curing waltz. Group cd, best timed for things. 
set variant cure to 50, second wind to 40
removed the favoring of till over espirit as requested. 
saw that as the reason to remove the second saber dance after til since it would be redundant
Removed antidrift options for none, both, and hold. went with .3f and .1f for triple weave
Went with 4001 and 4002 for simples? the number works, your section of ccp is very organized.


Aoe mode simple

Dance partner remains
Removed curing waltz and improv, variant to 50, second wind to 40
Set standard and tech hold for aoe to 25% bc trash
Saber dance set to 50. removed redundant saber dance code that seems to be a copy from st tilliana over espirit stuff that isnt present.