### PR TITLE
[DRK] Fix `Shadowbringer` pooling, AoE combos, Blood-blocking

### DIFF
--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -1331,12 +1331,12 @@ internal partial class DRK
     private enum Combo
     {
         // Target-type for combo
-        ST = 0,
-        AoE = 1,
+        ST = 1 << 0, // 1
+        AoE = 1 << 1, // 2
 
         // Complexity of combo
-        Adv = 2,
-        Simple = 4,
+        Adv = 1 << 2, // 4
+        Simple = 1 << 3, // 8
     }
 
     private interface IActionProvider

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -325,7 +325,8 @@ internal partial class DRK
                  !IsEnabled(Preset.DRK_ST_CD_BringerBurst)) ||
                 (flags.HasFlag(Combo.Adv) && flags.HasFlag(Combo.ST) &&
                  IsEnabled(Preset.DRK_ST_CD_BringerBurst) &&
-                 IsOnCooldown(LivingShadow) && !HasEffect(Buffs.Scorn));
+                 GetCooldownRemainingTime(LivingShadow) >= 90 &&
+                 !HasEffect(Buffs.Scorn));
 
             #endregion
 

--- a/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
+++ b/WrathCombo/Combos/PvE/DRK/DRK_Helper.cs
@@ -44,6 +44,9 @@ internal partial class DRK
     /// </summary>
     private static DRKGauge Gauge => GetJobGauge<DRKGauge>();
 
+    /// <summary>
+    ///     DRK's GCD, truncated to two decimal places.
+    /// </summary>
     private static double GCD => GetCooldown(HardSlash).CooldownTotal;
 
     /// <summary>

--- a/WrathCombo/CustomCombo/WrathOpener.cs
+++ b/WrathCombo/CustomCombo/WrathOpener.cs
@@ -225,7 +225,8 @@ namespace WrathCombo.CustomComboNS
                         CurrentOpenerAction = OpenerActions[OpenerStep - 1];
                     }
 
-                    while (OpenerStep > 1 && !ActionReady(CurrentOpenerAction) && ActionWatching.TimeSinceLastAction.TotalSeconds > Math.Max(3, GCDTotal))
+                    while (OpenerStep > 1 && !ActionReady(CurrentOpenerAction) &&
+                           ActionWatching.TimeSinceLastAction.TotalSeconds > Math.Max(1.5, GCDTotal))
                     {
                         if (OpenerStep >= OpenerActions.Count)
                             break;


### PR DESCRIPTION
- [X] Corrects `Shadowbringer` burst-pooling option to correctly check for the burst window\
      (to close [this discord report](https://discord.com/channels/1001823907193552978/1337808512733937714))
- [X] Lowers Opener failure window down to what it was
- [X] Fix ST skills in AoE combos\
      (to close [this discord report](https://discord.com/channels/1001823907193552978/1337772855349215242))
- [X] Fix Blood skills blocking Mana skills\
      (to partially close [this discord report](https://discord.com/channels/1001823907193552978/1337873678523826267))
- [X] Fix Bloodspiller-before-Delirium\
      (to partially close [this discord report](https://discord.com/channels/1001823907193552978/1337873678523826267))