### PR TITLE
[DNC] restructure features

### DIFF
--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1352,12 +1352,43 @@ public enum CustomComboPreset
 
     #region Dance Features
 
-    [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-    [ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
-    [CustomComboInfo("Dance Step Combo Feature",
-        "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //[ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
+    //[ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
+    //[CustomComboInfo("Dance Step Combo Feature",
+    //    "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //    "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    //DNC_DanceStepCombo = 4110,
+
+    [CustomComboInfo("Dance Features", "Modifies default dance behaviors.", DNC.JobID)]
+    DNC_DanceFeatures = 4110,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.StandardStep)]
+    [CustomComboInfo("Standard Step Combo Feature",
+        "Change Standard Step into each dance step, while dancing." +
         "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    DNC_DanceStepCombo = 4110,
+    DNC_StandardStepCombo = 4111,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step Combo Feature",
+        "Change Technical Step into each dance step, while dancing." +
+        "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    DNC_TechnicalStepCombo = 4112,
+
+    // StandardStep(or Finishing Move) --> Last Dance
+    [ParentCombo(DNC_StandardStepCombo)]
+    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
+    [CustomComboInfo("Standard Step to Last Dance Feature",
+        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
+    DNC_StandardStep_LastDance = 4155,
+
+    // Technical Step --> Devilment
+    [ParentCombo(DNC_TechnicalStepCombo)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
+        DNC.JobID)]
+    DNC_TechnicalStep_Devilment = 4160,
 
     [CustomComboInfo("Custom Dance Step Feature",
         "Change custom actions into dance steps while dancing." +
@@ -1416,20 +1447,6 @@ public enum CustomComboPreset
     [ReplaceSkill(DNC.Devilment)]
     [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID)]
     DNC_Starfall_Devilment = 4150,
-
-    // StandardStep(or Finishing Move) --> Last Dance
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_DanceStepCombo)]
-    [CustomComboInfo("Standard Step to Last Dance Feature",
-        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
-    DNC_StandardStep_LastDance = 4155,
-
-    // Technical Step --> Devilment
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_DanceStepCombo)]
-    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
-        DNC.JobID)]
-    DNC_TechnicalStep_Devilment = 4160,
 
     // Bladeshower --> Bloodshower
     [ReplaceSkill(DNC.Bladeshower)]

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1374,14 +1374,14 @@ internal partial class DNC : PhysicalRanged
 
     #region Dance Features
 
-    internal class DNC_DanceStepCombo : CustomCombo
+    internal class DNC_StandardStepCombo : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_DanceStepCombo;
+            CustomComboPreset.DNC_StandardStepCombo;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (StandardStep or TechnicalStep)) return actionID;
+            if (actionID is not StandardStep) return actionID;
 
             // Standard Step
             if (actionID is StandardStep && Gauge.IsDancing &&
@@ -1389,6 +1389,19 @@ internal partial class DNC : PhysicalRanged
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
                     : FinishOrHold(StandardFinish2);
+
+            return actionID;
+        }
+    }
+
+    internal class DNC_TechnicalStepCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset =>
+            CustomComboPreset.DNC_TechnicalStepCombo;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not TechnicalStep) return actionID;
 
             // Technical Step
             if (actionID is TechnicalStep && Gauge.IsDancing &&


### PR DESCRIPTION
reformat to have in a structure like this:
Dance Features (does nothing)
- Standard Steps Feature (replace Standard with its steps)
  - Standard to Last Dance Feature
- Technical Steps Feature (replace Technical with its steps)
  - Technical to Devilment Feature  
- Custom Dance Steps Feature

This should allow for more standard nesting and also disable the conflict flags on the Standard to Last Dance Feature as well as Technical to Devilment Feature  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced combat targeting now considers vertical differences to improve engagement accuracy.
	- Expanded dancer combo customization provides new standard and technical dance move options along with refined sequence controls.
	- The debug view now displays target height information for improved situational awareness.

- **Chores**
	- Updated internal compatibility and dependency settings for enhanced performance and smoother operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->