### PR TITLE
restructure dnc dance features

### DIFF
--- a/WrathCombo/AutoRotation/AutoRotationController.cs
+++ b/WrathCombo/AutoRotation/AutoRotationController.cs
@@ -559,7 +559,7 @@ namespace WrathCombo.AutoRotation
 
         public class DPSTargeting
         {
-            private static bool Query(IGameObject x) => x is IBattleChara chara && chara.IsHostile() && IsInRange(chara, cfg.DPSSettings.MaxDistance) && !chara.IsDead && chara.IsTargetable && IsInLineOfSight(chara) && !TargetIsInvincible(chara) && !Service.Configuration.IgnoredNPCs.Any(x => x.Key == chara.DataId) &&
+            private static bool Query(IGameObject x) => x is IBattleChara chara && chara.IsHostile() && IsInRange(chara, cfg.DPSSettings.MaxDistance) && GetTargetHeightDifference(chara) <= 3 && !chara.IsDead && chara.IsTargetable && IsInLineOfSight(chara) && !TargetIsInvincible(chara) && !Service.Configuration.IgnoredNPCs.Any(x => x.Key == chara.DataId) &&
                 ((cfg.DPSSettings.OnlyAttackInCombat && chara.Struct()->InCombat) || !cfg.DPSSettings.OnlyAttackInCombat);
             public static IEnumerable<IGameObject> BaseSelection => Svc.Objects.Any(x => Query(x) && IsPriority(x)) ?
                                                                     Svc.Objects.Where(x => Query(x) && IsPriority(x)) :

--- a/WrathCombo/Combos/CustomComboPreset.cs
+++ b/WrathCombo/Combos/CustomComboPreset.cs
@@ -1274,12 +1274,43 @@ public enum CustomComboPreset
 
     #region Dance Features
 
-    [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-    [ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
-    [CustomComboInfo("Dance Step Combo Feature",
-        "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //[ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
+    //[ConflictingCombos(DNC_StandardStep_LastDance, DNC_TechnicalStep_Devilment)]
+    //[CustomComboInfo("Dance Step Combo Feature",
+    //    "Change Standard Step and Technical Step into each dance step, while dancing." +
+    //    "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    //DNC_DanceStepCombo = 4110,
+
+    [CustomComboInfo("Dance Features", "Modifies default dance behaviors.", DNC.JobID)]
+    DNC_DanceFeatures = 4110,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.StandardStep)]
+    [CustomComboInfo("Standard Step Combo Feature",
+        "Change Standard Step into each dance step, while dancing." +
         "\nWorks with Advanced Mode DNC.", DNC.JobID)]
-    DNC_DanceStepCombo = 4110,
+    DNC_StandardStepCombo = 4111,
+
+    [ParentCombo(DNC_DanceFeatures)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step Combo Feature",
+        "Change Technical Step into each dance step, while dancing." +
+        "\nWorks with Advanced Mode DNC.", DNC.JobID)]
+    DNC_TechnicalStepCombo = 4112,
+
+    // StandardStep(or Finishing Move) --> Last Dance
+    [ParentCombo(DNC_StandardStepCombo)]
+    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
+    [CustomComboInfo("Standard Step to Last Dance Feature",
+        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
+    DNC_StandardStep_LastDance = 4155,
+
+    // Technical Step --> Devilment
+    [ParentCombo(DNC_TechnicalStepCombo)]
+    [ReplaceSkill(DNC.TechnicalStep)]
+    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
+        DNC.JobID)]
+    DNC_TechnicalStep_Devilment = 4160,
 
     [CustomComboInfo("Custom Dance Step Feature",
         "Change custom actions into dance steps while dancing." +
@@ -1338,20 +1369,6 @@ public enum CustomComboPreset
     [ReplaceSkill(DNC.Devilment)]
     [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID)]
     DNC_Starfall_Devilment = 4150,
-
-    // StandardStep(or Finishing Move) --> Last Dance
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_DanceStepCombo, DNC_TechnicalStep_Devilment)]
-    [CustomComboInfo("Standard Step to Last Dance Feature",
-        "Change Standard Step or Finishing Move to Last Dance when available.", DNC.JobID)]
-    DNC_StandardStep_LastDance = 4155,
-
-    // Technical Step --> Devilment
-    [ReplaceSkill(DNC.StandardStep, DNC.FinishingMove)]
-    [ConflictingCombos(DNC_StandardStep_LastDance, DNC_DanceStepCombo)]
-    [CustomComboInfo("Technical Step to Devilment Feature", "Change Technical Step to Devilment as soon as possible.",
-        DNC.JobID)]
-    DNC_TechnicalStep_Devilment = 4160,
 
     // Bladeshower --> Bloodshower
     [ReplaceSkill(DNC.Bladeshower)]

--- a/WrathCombo/Combos/PvE/ALL/JobClasses.cs
+++ b/WrathCombo/Combos/PvE/ALL/JobClasses.cs
@@ -6,7 +6,7 @@ namespace WrathCombo.Combos.PvE;
 //Examples
 // GNB.Role.Interject would work, SGE.Role.Interject would not.
 //THis should help for future jobs and future random actions to quickly wireup job appropriate actions
-class HealerJob : Healer
+class HealerJob
 {
     public class Variant : VariantHealer;
     public class Role : Healer;

--- a/WrathCombo/Combos/PvE/DNC/DNC.cs
+++ b/WrathCombo/Combos/PvE/DNC/DNC.cs
@@ -1357,14 +1357,14 @@ internal partial class DNC : PhysRangedJob
 
     #region Dance Features
 
-    internal class DNC_DanceStepCombo : CustomCombo
+    internal class DNC_StandardStepCombo : CustomCombo
     {
         protected internal override CustomComboPreset Preset =>
-            CustomComboPreset.DNC_DanceStepCombo;
+            CustomComboPreset.DNC_StandardStepCombo;
 
         protected override uint Invoke(uint actionID)
         {
-            if (actionID is not (StandardStep or TechnicalStep)) return actionID;
+            if (actionID is not StandardStep) return actionID;
 
             // Standard Step
             if (actionID is StandardStep && Gauge.IsDancing &&
@@ -1372,6 +1372,19 @@ internal partial class DNC : PhysRangedJob
                 return Gauge.CompletedSteps < 2
                     ? Gauge.NextStep
                     : FinishOrHold(StandardFinish2);
+
+            return actionID;
+        }
+    }
+
+    internal class DNC_TechnicalStepCombo : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset =>
+            CustomComboPreset.DNC_TechnicalStepCombo;
+
+        protected override uint Invoke(uint actionID)
+        {
+            if (actionID is not TechnicalStep) return actionID;
 
             // Technical Step
             if (actionID is TechnicalStep && Gauge.IsDancing &&

--- a/WrathCombo/CustomCombo/Functions/Target.cs
+++ b/WrathCombo/CustomCombo/Functions/Target.cs
@@ -53,6 +53,22 @@ namespace WrathCombo.CustomComboNS.Functions
             return Math.Max(0, Vector2.Distance(position, selfPosition) - chara.HitboxRadius - sourceChara.HitboxRadius);
         }
 
+        public static float GetTargetHeightDifference(IGameObject? target = null, IGameObject? source = null)
+        {
+            if (LocalPlayer is null)
+                return 0;
+
+            IGameObject? chara = target != null ? target : CurrentTarget != null ? CurrentTarget : null;
+            if (chara is null) return 0;
+
+            IGameObject? sourceChara = source != null ? source : LocalPlayer;
+
+            if (chara.GameObjectId == sourceChara.GameObjectId)
+                return 0;
+
+            return Math.Max(0, Math.Abs(chara.Position.Y - sourceChara.Position.Y));
+        }
+
         /// <summary> Gets a value indicating whether you are in melee range from the current target. </summary>
         /// <returns> Bool indicating whether you are in melee range. </returns>
         public static bool InMeleeRange()

--- a/WrathCombo/Services/IPC/Search.cs
+++ b/WrathCombo/Services/IPC/Search.cs
@@ -555,6 +555,7 @@ public class Search(Leasing leasing)
     /// </summary>
     internal Dictionary<CustomComboPreset, bool> AutoActions =>
         PresetStates
+        .Where(x => Enum.Parse<CustomComboPreset>(x.Key).Attributes().AutoAction is not null)
             .ToDictionary(
                 preset => Enum.Parse<CustomComboPreset>(preset.Key),
                 preset => preset.Value[ComboStateKeys.AutoMode]

--- a/WrathCombo/Window/Tabs/Debug.cs
+++ b/WrathCombo/Window/Tabs/Debug.cs
@@ -320,6 +320,7 @@ namespace WrathCombo.Window.Tabs
                 CustomStyleText("Is BattleChara:", target is IBattleChara);
                 CustomStyleText("Is PlayerCharacter:", target is IPlayerCharacter);
                 CustomStyleText("Distance:", $"{Math.Round(GetTargetDistance(), 2)}y");
+                CustomStyleText("Height:", $"{Math.Round(GetTargetHeightDifference(), 2)}y");
                 CustomStyleText("Hitbox Radius:", target?.HitboxRadius);
                 CustomStyleText("In Melee Range:", InMeleeRange());
                 CustomStyleText("Requires Postionals:", TargetNeedsPositionals());

--- a/WrathCombo/WrathCombo.csproj
+++ b/WrathCombo/WrathCombo.csproj
@@ -9,7 +9,7 @@
         <Description>XIVCombo for very lazy players</Description>
         <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
         <PackageProjectUrl></PackageProjectUrl>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net9.0-windows</TargetFramework>
         <Configurations>Debug;Release</Configurations>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
     </PropertyGroup>
@@ -68,7 +68,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="DalamudPackager" Version="11.0.0"/>
+        <PackageReference Include="DalamudPackager" Version="12.0.0"/>
         <PackageReference Include="ILRepack" Version="2.0.18"/>
     </ItemGroup>
 

--- a/WrathCombo/WrathCombo.json
+++ b/WrathCombo/WrathCombo.json
@@ -2,7 +2,7 @@
   "Author": "Team Wrath",
   "Name": "Wrath Combo",
   "InternalName": "WrathCombo",
-  "DalamudApiLevel": 11,
+  "DalamudApiLevel": 12,
   "Punchline": "Condenses combos and mutually exclusive abilities onto a single button - and then some.",
   "Description": "Condenses combos and mutually exclusive abilities onto a single button - and then some.",
   "RepoUrl": "https://github.com/PunishXIV/WrathCombo",


### PR DESCRIPTION
reformat to have in a structure like this:
Dance Features (does nothing)
- Standard Steps Feature (replace Standard with its steps)
  - Standard to Last Dance Feature
- Technical Steps Feature (replace Technical with its steps)
  - Technical to Devilment Feature
- Custom Dance Steps Feature

This should allow for more standard nesting and also disable the conflict flags on the Standard to Last Dance Feature as well as Technical to Devilment Feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced combat targeting with an added vertical height check, improving target precision.
  - Expanded combo customization for dancers with new, granular control over dance steps.
  - Introduced target height information in the debug view for better in-game diagnostics.

- **Bug Fixes**
  - Refined auto-action filtering to display only valid presets.

- **Refactor**
  - Streamlined job class structures for improved gameplay consistency.

- **Chores**
  - Updated underlying dependencies, framework, and API level for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->